### PR TITLE
Fix links in Readme.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to SwiftyTesseractRTE
-1. First and foremorest, adhere to the [Contributor Code of Conduct](ContributorCodeOfConduct.md)!
+1. First and foremorest, adhere to the [Contributor Code of Conduct](CODE_OF_CONDUCT.md)!
 2. If you are making a contribution without an open issue, create an issue and then perform a pull request.
 3. If you are adding a feature, you must include a passing test for the new functionality to be considered as well as inline documentation.
 4. Make sure to review any open pull requests before performing your own on an existing issue. There may already be a fix pending review!

--- a/Readme.md
+++ b/Readme.md
@@ -119,10 +119,10 @@ $ pod install
 ```
 
 ## Setting Up SwiftyTesseract for Use in SwiftyTesseractRTE
-See SwiftyTesseract's [Additional Configuration](https://github.com/SwiftyTesseract/SwiftyTesseract/blob/master/Readme.md#additional-configuration) section on properly setting up SwiftyTesseract to be utilized in your project.
+See SwiftyTesseract's [Additional Configuration](https://github.com/SwiftyTesseract/SwiftyTesseract/blob/master/README.md#additional-configuration) section on properly setting up SwiftyTesseract to be utilized in your project.
 
 ## Documentation
 Official documentation for SwiftyTesseractRTE can be found [here](https://swiftytesseract.github.io/SwiftyTesseractRTE/)
 
 # Contributions Welcome
-Contributions are always welcome! Please refer to [Contributing to SwiftyTesseractRTE](https://github.com/SwiftyTesseract/SwiftyTesseractRTE/blob/master/Contributions.md) for the full guidelines on creating issues and opening pull requests to the project.
+Contributions are always welcome! Please refer to [Contributing to SwiftyTesseractRTE](https://github.com/SwiftyTesseract/SwiftyTesseractRTE/blob/master/CONTRIBUTING.md) for the full guidelines on creating issues and opening pull requests to the project.


### PR DESCRIPTION
## Overview

Fixed links in Readme.md and CONTRIBUTING.md files. I omitted an issue for this because this fix is just for documentations. 🙏 

## Test

I confirmed that I jumped to the correct pages by those fixed links using browser.